### PR TITLE
Improve interactive development experience

### DIFF
--- a/src/chameleon.lisp
+++ b/src/chameleon.lisp
@@ -11,6 +11,9 @@
 
 (in-package chameleon)
 
+(defvar *profile-type* :variable
+  "Type of form to use for profile definitions (:VARIABLE or :PARAMETER).")
+
 (define-condition null-profile-error (error) ()
   (:report (lambda (condition stream)
              (declare (ignore condition))
@@ -132,14 +135,17 @@ to insert some code."
          (profile-sym (symbolicate 'profile)))
     `(progn
        ;; Generate 'config instance.
-       (defvar ,config-var-name
-         (funcall #'make-instance
-                  ',(symbolicate 'config)
-                  ,@(mapcan (lambda (pair)
-                              (assert (= (length pair) 2))
-                              (list (make-keyword (first pair))
-                                    (second pair)))
-                            configs)))
+       (,(ecase *profile-type*
+           (:parameter 'defparameter)
+           (:variable 'defvar))
+        ,config-var-name
+        (funcall #'make-instance
+                 ',(symbolicate 'config)
+                 ,@(mapcan (lambda (pair)
+                             (assert (= (length pair) 2))
+                             (list (make-keyword (first pair))
+                                   (second pair)))
+                           configs)))
 
        ;; Generate switch-profile method.
        (defmethod ,(symbolicate 'switch-profile) ((,profile-sym (eql ,name)))

--- a/src/chameleon.lisp
+++ b/src/chameleon.lisp
@@ -14,6 +14,8 @@
 (defvar *profile-type* :variable
   "Type of form to use for profile definitions (:VARIABLE or :PARAMETER).")
 
+(defvar *switch-profiles* nil "Automatically switch to a profile when defining it.")
+
 (define-condition null-profile-error (error) ()
   (:report (lambda (condition stream)
              (declare (ignore condition))
@@ -150,7 +152,11 @@ to insert some code."
        ;; Generate switch-profile method.
        (defmethod ,(symbolicate 'switch-profile) ((,profile-sym (eql ,name)))
          (setf ,(symbolicate '*config*) ,config-var-name)
-         (setf ,(symbolicate '*profile*) ,profile-sym)))))
+         (setf ,(symbolicate '*profile*) ,profile-sym))
+
+       ;; Optionally switch to the newly defined profile.
+       ,(when *switch-profiles*
+          `(,(symbolicate 'switch-profile) ,name)))))
 
 (defmacro eval-once (&body body)
   "Defines a closure to evaluate BODY for only once."

--- a/src/chameleon.lisp
+++ b/src/chameleon.lisp
@@ -12,9 +12,36 @@
 (in-package chameleon)
 
 (defvar *profile-type* :variable
-  "Type of form to use for profile definitions (:VARIABLE or :PARAMETER).")
+  "Type of form to use for profile definitions (:VARIABLE or :PARAMETER).
 
-(defvar *switch-profiles* nil "Automatically switch to a profile when defining it.")
+This special controls whether the variable that contains a configuration
+profile is defined using DEFVAR or DEFPARAMETER. When set to :VARIABLE,
+DEFPROFILE will define the profile using DEFVAR. When the form is re-
+evaluated the profile will not be updated, according to the semantics
+of DEFVAR.
+
+When set to :PARAMETER, DEFPROFILE will define profile variables using
+DEFPARAMETER, updating the active instance of the profile when the form
+is re-evaluated. This is useful for interactive development when modifying
+configuration profiles in the running image.
+
+The default value of *PROFILE-TYPE* is :VARIABLE.")
+
+(defvar *switch-profiles* nil
+  "Automatically switch to a profile when defining it (generalised boolean).
+
+This variable controls whether evaluating a DEFPROFILE form activates the
+new profile using a call to SWITCH-PROFILE. This facilitates interactive
+development by allowing redefining and activating a profile as a single
+operation. When a true value, profiles will be activated when evaluating
+a DEFPROFILE form, when NIL the profile will still be defined, but not
+activated.
+
+This behaviour respects the setting of *PROFILE-TYPE*, i.e. to redefine and
+activate an updated profile, *PROFILE-TYPE* should be :PARAMETER and
+ *SWITCH-PROFILES* should be T.
+
+The default value of *SWITCH-PROFILES* is NIL.")
 
 (define-condition null-profile-error (error) ()
   (:report (lambda (condition stream)


### PR DESCRIPTION
Hello, I have made a few small tweaks which enhance the interactive development experience when using Chameleon, if these are of interest.

The first allows user code to control whether a configuration profile variable is defined with DEFVAR or DEFPARAMETER. This is useful because re-evaluating a DEFPROFILE form after changing values does not create a new instance of the config class, which means the configuration reader function does not return updated values. This behaviour is controlled by the special *PROFILE-TYPE* which defaults to preserving the existing behaviour. 

The second allows switching to a profile at the time is is defined by inserting a call to SWITCH-PROFILE if the special *SWITCH-PROFILES* is true. The idea behind this is to allow interactively re-defining and activating a profile as a single operation at the REPL/SLIME. The default behaviour is not to do this to avoid breaking existing code, however a side effect is that this will change the result of the DEFPROFILE form to NIL when disabled. I don't consider this to be a major issue as this form appears intended to be used as a top-level form, but it seems worthy to draw to your attention.

Feel free to merge these changes if you feel they are of interest. I've tested them on LispWorks 8 and SBCL 2.1.9.